### PR TITLE
download-ignore-retry-after-header

### DIFF
--- a/olmo/data/download_urls.py
+++ b/olmo/data/download_urls.py
@@ -67,7 +67,8 @@ def _download_images(args):
     retries = Retry(
         total=3,
         backoff_factor=1,
-        status_forcelist=[429]
+        status_forcelist=[429],
+        respect_retry_after_header=False
     )
     session.mount('http://', HTTPAdapter(max_retries=retries))
     session.mount('https://', HTTPAdapter(max_retries=retries))
@@ -79,7 +80,7 @@ def _download_images(args):
         return DownloadError(url, ValueError('Not in cache'))
     else:
         try:
-            response = session.get(url, timeout=5)
+            response = session.get(url, **kwargs)
             response.raise_for_status()
             image_bytes = response.content
         except Exception as e:


### PR DESCRIPTION
- pass through kwargs that set timeout in the function call
- ignore retry after header as some URLs set them arbitrarily far in the future, causing the download script to hang eg:

```
(base) amith@Amiths-MacBook-Pro-4 metrics % curl -I https://www.avialogs.com/media/k2/items/cache/b53ad912c7950b115492257a5e8e3636_M.jpg
HTTP/1.1 503 Service Unavailable
Date: Thu, 31 Jul 2025 23:02:44 GMT
Server: Apache/2.4.58 (Ubuntu)
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
Referrer-Policy: strict-origin-when-cross-origin
**Retry-After: Sat, 10 Aug 2025 00:00:00 GMT**
Last-Modified: Tue, 24 Jun 2025 15:42:32 GMT
ETag: "3f2b-638532d34c015"
Accept-Ranges: bytes
Content-Length: 16171
Connection: close
Content-Type: text/html
```
